### PR TITLE
introduce install-reloader

### DIFF
--- a/python/k8s.py
+++ b/python/k8s.py
@@ -321,6 +321,17 @@ def install_cert_manager(version):
         f.close()
         config.kubectl.call(['apply', '-n', 'cert-manager', '-f', f.name])
 
+@k8s.command(flowdepends=['k8s.create-cluster'])
+@option('--version', default='v0.0.99', help="The version of reloader chart to install")
+def install_reloader(version):
+    """Install a reloader in the current cluster"""
+    call(['helm', 'repo', 'add', 'stakater', 'https://stakater.github.io/stakater-charts'])
+    call([
+        'helm', '--kube-context', config.kubectl.context,
+        'upgrade', '--install', '--create-namespace', '--wait', 'reloader', 'stakater/reloader',
+        '--namespace', 'reloader',
+        '--version', version,
+    ])  # yapf: disable
 
 @k8s.command(flowdepends=['k8s.create-cluster'])
 @argument('domain', help="The domain name to define")


### PR DESCRIPTION
This PR adds reloader install for automatic secret/configmap reloading (need an annotation)

By default, reloader will watch all namespaces (looks fine)