### PR TITLE
introduce install-dnsmasq

### DIFF
--- a/python/k8s.py
+++ b/python/k8s.py
@@ -303,6 +303,7 @@ def install_cert_manager(version):
         f.close()
         config.kubectl.call(['apply', '-n', 'cert-manager', '-f', f.name])
 
+
 @k8s.command(flowdepends=['k8s.create-cluster'])
 def install_dnsmasq():
     """Install a dnsmasq server resolving *.localhost to 127.0.0.1. Supported OS: macOS."""
@@ -316,9 +317,9 @@ def install_dnsmasq():
                 f.write("\naddress=/localhost/127.0.0.1\n")
         call(['sudo', 'brew', 'services', 'restart', 'dnsmasq'])
         call(['sudo', 'mkdir', '-p', '/etc/resolver'])
-        with temporary_file() as f:
-            f.write("nameserver 127.0.0.1\n".encode('utf8'))
+        with temporary_file(content='nameserver 127.0.0.1\n') as f:
             call(['sudo', 'cp', f.name, '/etc/resolver/localhost'])
+
 
 @k8s.command(flowdepends=['k8s.create-cluster'])
 @argument('domain', help="The domain name to define")


### PR DESCRIPTION
This PR adds a command to install DNSmasq on macOS and support for wildcard localhost domain.