### PR TITLE
Disable IPV6 for Kind

### DIFF
--- a/python/k8s.py
+++ b/python/k8s.py
@@ -265,6 +265,7 @@ nodes:
     protocol: TCP
 networking:
   disableDefaultCNI: true
+  ipFamily: ipv4
 """
 
 cluster_issuer = '''apiVersion: cert-manager.io/v1


### PR DESCRIPTION
Docker on mac does not support IPV6
https://kind.sigs.k8s.io/docs/user/configuration/#networking